### PR TITLE
Update CVE-2021-25966.json

### DIFF
--- a/cves/2021/25xxx/CVE-2021-25966.json
+++ b/cves/2021/25xxx/CVE-2021-25966.json
@@ -3,7 +3,7 @@
         "cna": {
             "affected": [
                 {
-                    "product": "Users",
+                    "product": "Orchard core CMS",
                     "vendor": "OrchardCore",
                     "versions": [
                         {


### PR DESCRIPTION
Fix error in affected product in CVE-2021-25966.

The correct product comes from the CVE description itself.